### PR TITLE
Add MacOS .app Support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,9 +31,19 @@ export async function run(context: AfterPackContext, options: RunOptions = {}) {
   await buildConfig()
   const encryptorConfig = getConfig()
 
-  const tempAppDir = path.join(context.appOutDir, '../', 'app')
+  let appOutDir = context.appOutDir
 
-  const resourcesDir = path.join(context.appOutDir, 'resources')
+  if (context.packager.platform.name === 'mac') {
+    appOutDir = path.join(
+      appOutDir,
+      `${context.packager.appInfo.productFilename}.app`,
+      'Contents'
+    )
+  }
+
+  const tempAppDir = path.join(appOutDir, '../', 'app')
+
+  const resourcesDir = path.join(appOutDir, 'resources')
   const appAsarPath = path.join(resourcesDir, 'app.asar')
 
   // 先解压到缓存目录
@@ -122,7 +132,7 @@ export async function run(context: AfterPackContext, options: RunOptions = {}) {
 
   if (encryptorConfig.renderer.output) {
     const rendererOutPath = path.join(
-      context.appOutDir,
+      appOutDir,
       encryptorConfig.renderer.output
     )
     const rendererOutDir = path.dirname(rendererOutPath)

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -7,7 +7,12 @@ import { getAppResourcesMap } from './decrypt'
 import { readAppAsarMd5, readAppAsarMd5Sync } from './encrypt'
 import { mergeDefaultConfig } from './default-config'
 
-const execDir = path.dirname(process.execPath)
+const platform = process.platform
+let execDir = path.dirname(process.execPath)
+
+if (platform === 'darwin') {
+  execDir = path.join(execDir, '..')
+}
 
 __encryptorConfig = mergeDefaultConfig(__encryptorConfig)
 


### PR DESCRIPTION
I really appreciate this project and wanted to add a contribution that I had made to get this to work with MacOS .app applications. When building .app applications on MacOS, the resources directory is in the <ApplicationName>.app/Contents directory, and the executable is in the <ApplicationName>.app/MacOS directory. I made some updates to the main run function and to the preload script to account for these. I haven't tested this with .pkg packages (these might need to be handled differently), but it works for .app applications.