### PR TITLE
Point to the correct output filename

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ export async function run(context: AfterPackContext, options: RunOptions = {}) {
   fs.renameSync(`${mainJsPath}.tmp`, mainJsPath)
 
   // 可执行文件
-  let execPath = path.join(appOutDir, packageJson.name)
+  let execPath = path.join(appOutDir, context.packager.appInfo.productFilename)
   if (context.packager.platform.name === 'windows') {
     execPath = `${execPath}.exe`
   }


### PR DESCRIPTION
If the package json name is different from the productFilename, the executable path will be incorrect. 

This PR just uses the productFilename since that should always be the name of the executable produced.