### PR TITLE
fix: add 'MacOS' subdirectory to 'execPath' for Mac builds

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,11 @@ export async function run(context: AfterPackContext, options: RunOptions = {}) {
   fs.renameSync(`${mainJsPath}.tmp`, mainJsPath)
 
   // 可执行文件
-  let execPath = path.join(appOutDir, context.packager.appInfo.productFilename)
+  let execPath = path.join(
+    appOutDir,
+    context.packager.platform.name === 'mac' ? 'MacOS' : '',
+    context.packager.appInfo.productFilename
+  )
   if (context.packager.platform.name === 'windows') {
     execPath = `${execPath}.exe`
   }


### PR DESCRIPTION
Adds the 'MacOS' sub-directory to executable path for Mac builds, see issue: https://github.com/dusionlike/electron-builder-encryptor/issues/11