### PR TITLE
The bundle-require dependency had a breaking change

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "adm-zip": "^0.5.9",
     "asar": "^3.2.0",
     "builder-util": "^23.4.0",
-    "bundle-require": "^4.0.2",
+    "bundle-require": "4.0.2",
     "esbuild-plugin-babel": "^0.2.3",
     "esbuild-plugin-babel-cjs": "^1.0.0",
     "mime": "^3.0.0",


### PR DESCRIPTION
4.0.3 of bundle-require now marks node_modules as external by default which causes an error when loading the encryptor.config.js file.

https://github.com/egoist/bundle-require/pull/41

As a quick fix, we can use 4.0.2 for now. Though there's probably a better way of working with it