### PR TITLE
Fix for windows path resolution issue introduced by adm-zip update

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 7.24.3(@babel/core@7.24.3)
       adm-zip:
         specifier: ^0.5.9
-        version: 0.5.9
+        version: 0.5.14
       asar:
         specifier: ^3.2.0
         version: 3.2.0
@@ -43,7 +43,7 @@ importers:
         version: 1.2.0
       tsup:
         specifier: ^7.3.0
-        version: 7.3.0(typescript@4.7.4)
+        version: 7.3.0(postcss@8.4.14)(typescript@4.7.4)
       yaml:
         specifier: ^2.1.1
         version: 2.1.1
@@ -62,7 +62,7 @@ importers:
         version: 2.3.5(eslint@8.20.0)(typescript@4.7.4)
       '@types/adm-zip':
         specifier: ^0.5.0
-        version: 0.5.0
+        version: 0.5.5
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
@@ -104,7 +104,7 @@ importers:
     dependencies:
       adm-zip:
         specifier: ^0.5.9
-        version: 0.5.9
+        version: 0.5.14
       bytenode:
         specifier: ^1.3.6
         version: 1.3.6
@@ -120,7 +120,7 @@ importers:
     devDependencies:
       '@types/adm-zip':
         specifier: ^0.5.0
-        version: 0.5.0
+        version: 0.5.5
       '@types/mime':
         specifier: ^3.0.1
         version: 3.0.1
@@ -1047,8 +1047,8 @@ packages:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
 
-  '@types/adm-zip@0.5.0':
-    resolution: {integrity: sha512-FCJBJq9ODsQZUNURo5ILAQueuA8WJhRvuihS3ke2iI25mJlfV2LK8jG2Qj2z2AWg8U0FtWWqBHVRetceLskSaw==}
+  '@types/adm-zip@0.5.5':
+    resolution: {integrity: sha512-YCGstVMjc4LTY5uK9/obvxBya93axZOVOyf2GSUulADzmLhYE45u2nAssCs/fWBs1Ifq5Vat75JTPwd5XZoPJw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1210,9 +1210,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adm-zip@0.5.9:
-    resolution: {integrity: sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg==}
-    engines: {node: '>=6.0'}
+  adm-zip@0.5.14:
+    resolution: {integrity: sha512-DnyqqifT4Jrcvb8USYjp6FHtBpEIz1mnXu6pTRHZ0RL69LbQYiO+0lDFg5+OKA7U29oWSs3a/i8fhn8ZcceIWg==}
+    engines: {node: '>=12.0'}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -4413,13 +4413,13 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@sxzz/eslint-config-basic@2.3.5(@typescript-eslint/parser@5.32.0)(eslint@8.20.0)':
+  '@sxzz/eslint-config-basic@2.3.5(@typescript-eslint/parser@5.32.0(eslint@8.20.0)(typescript@4.7.4))(eslint@8.20.0)':
     dependencies:
       eslint: 8.20.0
       eslint-define-config: 1.6.0
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.20.0)
       eslint-plugin-html: 7.1.0
-      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.32.0)(eslint@8.20.0)
+      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.32.0(eslint@8.20.0)(typescript@4.7.4))(eslint@8.20.0)
       eslint-plugin-jsonc: 2.3.1(eslint@8.20.0)
       eslint-plugin-markdown: 3.0.0(eslint@8.20.0)
       eslint-plugin-unicorn: 43.0.2(eslint@8.20.0)
@@ -4435,7 +4435,7 @@ snapshots:
       eslint: 8.20.0
       eslint-config-prettier: 8.5.0(eslint@8.20.0)
       eslint-define-config: 1.6.0
-      eslint-plugin-prettier: 4.2.1(eslint-config-prettier@8.5.0)(eslint@8.20.0)(prettier@2.7.1)
+      eslint-plugin-prettier: 4.2.1(eslint-config-prettier@8.5.0(eslint@8.20.0))(eslint@8.20.0)(prettier@2.7.1)
       eslint-plugin-yml: 1.0.0(eslint@8.20.0)
       prettier: 2.7.1
     transitivePeerDependencies:
@@ -4443,8 +4443,8 @@ snapshots:
 
   '@sxzz/eslint-config-ts@2.3.5(eslint@8.20.0)(typescript@4.7.4)':
     dependencies:
-      '@sxzz/eslint-config-basic': 2.3.5(@typescript-eslint/parser@5.32.0)(eslint@8.20.0)
-      '@typescript-eslint/eslint-plugin': 5.32.0(@typescript-eslint/parser@5.32.0)(eslint@8.20.0)(typescript@4.7.4)
+      '@sxzz/eslint-config-basic': 2.3.5(@typescript-eslint/parser@5.32.0(eslint@8.20.0)(typescript@4.7.4))(eslint@8.20.0)
+      '@typescript-eslint/eslint-plugin': 5.32.0(@typescript-eslint/parser@5.32.0(eslint@8.20.0)(typescript@4.7.4))(eslint@8.20.0)(typescript@4.7.4)
       '@typescript-eslint/parser': 5.32.0(eslint@8.20.0)(typescript@4.7.4)
       eslint: 8.20.0
       eslint-define-config: 1.6.0
@@ -4485,7 +4485,7 @@ snapshots:
 
   '@tootallnate/once@2.0.0': {}
 
-  '@types/adm-zip@0.5.0':
+  '@types/adm-zip@0.5.5':
     dependencies:
       '@types/node': 18.6.2
 
@@ -4592,7 +4592,7 @@ snapshots:
       '@types/node': 18.6.2
     optional: true
 
-  '@typescript-eslint/eslint-plugin@5.32.0(@typescript-eslint/parser@5.32.0)(eslint@8.20.0)(typescript@4.7.4)':
+  '@typescript-eslint/eslint-plugin@5.32.0(@typescript-eslint/parser@5.32.0(eslint@8.20.0)(typescript@4.7.4))(eslint@8.20.0)(typescript@4.7.4)':
     dependencies:
       '@typescript-eslint/parser': 5.32.0(eslint@8.20.0)(typescript@4.7.4)
       '@typescript-eslint/scope-manager': 5.32.0
@@ -4605,6 +4605,7 @@ snapshots:
       regexpp: 3.2.0
       semver: 7.3.7
       tsutils: 3.21.0(typescript@4.7.4)
+    optionalDependencies:
       typescript: 4.7.4
     transitivePeerDependencies:
       - supports-color
@@ -4616,6 +4617,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 5.32.0(typescript@4.7.4)
       debug: 4.3.4
       eslint: 8.20.0
+    optionalDependencies:
       typescript: 4.7.4
     transitivePeerDependencies:
       - supports-color
@@ -4631,6 +4633,7 @@ snapshots:
       debug: 4.3.4
       eslint: 8.20.0
       tsutils: 3.21.0(typescript@4.7.4)
+    optionalDependencies:
       typescript: 4.7.4
     transitivePeerDependencies:
       - supports-color
@@ -4646,6 +4649,7 @@ snapshots:
       is-glob: 4.0.3
       semver: 7.3.7
       tsutils: 3.21.0(typescript@4.7.4)
+    optionalDependencies:
       typescript: 4.7.4
     transitivePeerDependencies:
       - supports-color
@@ -4676,7 +4680,7 @@ snapshots:
 
   acorn@8.7.1: {}
 
-  adm-zip@0.5.9: {}
+  adm-zip@0.5.14: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -5481,12 +5485,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.7.3(@typescript-eslint/parser@5.32.0)(eslint-import-resolver-node@0.3.6):
+  eslint-module-utils@2.7.3(@typescript-eslint/parser@5.32.0(eslint@8.20.0)(typescript@4.7.4))(eslint-import-resolver-node@0.3.6):
     dependencies:
-      '@typescript-eslint/parser': 5.32.0(eslint@8.20.0)(typescript@4.7.4)
       debug: 3.2.7
-      eslint-import-resolver-node: 0.3.6
       find-up: 2.1.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 5.32.0(eslint@8.20.0)(typescript@4.7.4)
+      eslint-import-resolver-node: 0.3.6
     transitivePeerDependencies:
       - supports-color
 
@@ -5500,16 +5505,15 @@ snapshots:
     dependencies:
       htmlparser2: 8.0.1
 
-  eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.32.0)(eslint@8.20.0):
+  eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.32.0(eslint@8.20.0)(typescript@4.7.4))(eslint@8.20.0):
     dependencies:
-      '@typescript-eslint/parser': 5.32.0(eslint@8.20.0)(typescript@4.7.4)
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 8.20.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3(@typescript-eslint/parser@5.32.0)(eslint-import-resolver-node@0.3.6)
+      eslint-module-utils: 2.7.3(@typescript-eslint/parser@5.32.0(eslint@8.20.0)(typescript@4.7.4))(eslint-import-resolver-node@0.3.6)
       has: 1.0.3
       is-core-module: 2.9.0
       is-glob: 4.0.3
@@ -5517,6 +5521,8 @@ snapshots:
       object.values: 1.1.5
       resolve: 1.22.1
       tsconfig-paths: 3.14.1
+    optionalDependencies:
+      '@typescript-eslint/parser': 5.32.0(eslint@8.20.0)(typescript@4.7.4)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -5536,12 +5542,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.5.0)(eslint@8.20.0)(prettier@2.7.1):
+  eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.5.0(eslint@8.20.0))(eslint@8.20.0)(prettier@2.7.1):
     dependencies:
       eslint: 8.20.0
-      eslint-config-prettier: 8.5.0(eslint@8.20.0)
       prettier: 2.7.1
       prettier-linter-helpers: 1.0.0
+    optionalDependencies:
+      eslint-config-prettier: 8.5.0(eslint@8.20.0)
 
   eslint-plugin-unicorn@43.0.2(eslint@8.20.0):
     dependencies:
@@ -6489,10 +6496,12 @@ snapshots:
 
   pnpm@7.9.0: {}
 
-  postcss-load-config@4.0.2:
+  postcss-load-config@4.0.2(postcss@8.4.14):
     dependencies:
       lilconfig: 3.1.1
       yaml: 2.4.1
+    optionalDependencies:
+      postcss: 8.4.14
 
   postcss-selector-parser@6.0.10:
     dependencies:
@@ -6894,7 +6903,7 @@ snapshots:
 
   tslib@1.14.1: {}
 
-  tsup@7.3.0(typescript@4.7.4):
+  tsup@7.3.0(postcss@8.4.14)(typescript@4.7.4):
     dependencies:
       bundle-require: 4.0.2(esbuild@0.19.12)
       cac: 6.7.12
@@ -6904,12 +6913,14 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2
+      postcss-load-config: 4.0.2(postcss@8.4.14)
       resolve-from: 5.0.0
       rollup: 4.13.1
       source-map: 0.8.0-beta.0
       sucrase: 3.25.0
       tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.4.14
       typescript: 4.7.4
     transitivePeerDependencies:
       - supports-color

--- a/src/decrypt.ts
+++ b/src/decrypt.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto'
+import { normalize } from 'path'
 import AdmZip from 'adm-zip'
 import { md5Salt } from './encrypt'
 
@@ -30,7 +31,10 @@ export function getAppResourcesMap(rendererBuffer: Buffer, key?: string) {
       getData: () => any
     }) => {
       if (zip.isDirectory === false) {
-        appResourcesMap.set(zip.entryName.toString(), zip.getData())
+        //Ensure that entries have forward slashes
+        //Windows gets backslashes that have to be converted
+        const entryName = zip.entryName.toString().replaceAll('\\', '/')
+        appResourcesMap.set(entryName, zip.getData())
       }
     }
   )

--- a/src/decrypt.ts
+++ b/src/decrypt.ts
@@ -1,5 +1,4 @@
 import crypto from 'crypto'
-import { normalize } from 'path'
 import AdmZip from 'adm-zip'
 import { md5Salt } from './encrypt'
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -52,6 +52,7 @@ export function runRenderer(scheme = appProtocol) {
   protocol.registerBufferProtocol(scheme, (request, callback) => {
     try {
       let url = request.url.replace(`${scheme}://apps/`, '')
+      url = url.replaceAll('\\', '/') //Ensure we match the entries produced in the map
       url = url.split(/#|\?/)[0]
       callback({
         data: appResourcesMap.get(url),


### PR DESCRIPTION
In either version 0.5.13 or 0.5.14 of adm-zip, the entry names on windows contain backslashes when they used to be forward slashes. This causes the appResourcesMap to not match up with requests when they're inside folders within the renderer package.

Was working when using 0.5.12 of adm-zip