### PR TITLE
fix execSync when execSync includes space

### DIFF
--- a/src/encrypt.ts
+++ b/src/encrypt.ts
@@ -28,7 +28,7 @@ export async function compileToBytenode(
 
   await fs.promises.writeFile(compilerFilePath, compilerCode, 'utf-8')
 
-  execSync(`${execPath} ${compilerFilePath}`)
+  execSync(`"${execPath}" ${compilerFilePath}`)
 
   await fs.promises.unlink(compilerFilePath)
 }


### PR DESCRIPTION
修改execPath 有空格的case